### PR TITLE
Prevent duplicate contract addresses

### DIFF
--- a/app/scripts/globalFuncs.js
+++ b/app/scripts/globalFuncs.js
@@ -318,7 +318,7 @@ globalFuncs.saveTokenToLocal = function(localToken, callback) {
         // catch if CONTRACT ADDRESS is already in storedTokens
         for (var i = 0; i < storedTokens.length; i++){
             if (storedTokens[i].contractAddress.toLowerCase().replace(/ /g, '') === localToken.contractAdd.toLowerCase().replace(/ /g, '')) {
-              throw Error('ERROR: Unable to add a custom token with the same contract address as an existing custom token')
+              throw Error('ERROR: Unable to add custom token. It has the same address as custom token ' + storedTokens[i].symbol + '.')
             }
         }
 

--- a/app/scripts/globalFuncs.js
+++ b/app/scripts/globalFuncs.js
@@ -280,6 +280,27 @@ globalFuncs.doesTokenExistInDefaultTokens = function(token, defaultTokensAndNetw
   return false
 };
 
+function checkDuplicateTokenAddress(tokenOne, tokenTwo, currentNetwork) {
+  var hasNetwork = tokenTwo.network;
+  if (hasNetwork) {
+    return tokenTwo.network === currentNetwork && tokenTwo.contractAdd === tokenOne.address
+  } else {
+    return tokenTwo.contractAdd === tokenOne.address
+  }
+}
+
+globalFuncs.doesTokenAddressExistInDefaultTokenAddresses = function(token, defaultTokensAndNetworkType) {
+  for (var i = 0; i < defaultTokensAndNetworkType.defaultTokens.length; i++) {
+    var currentDefaultToken = defaultTokensAndNetworkType.defaultTokens[i];
+    var isDuplicateToken = checkDuplicateTokenAddress(currentDefaultToken, token, defaultTokensAndNetworkType.networkType);
+    // do not simplify to return isDuplicateToken
+    if (isDuplicateToken) {
+      return true
+    }
+  }
+  return false
+};
+
 globalFuncs.saveTokenToLocal = function(localToken, callback) {
     try {
         if (!ethFuncs.validateEtherAddress(localToken.contractAdd)) {throw globalFuncs.errorMsgs[5]}
@@ -287,20 +308,33 @@ globalFuncs.saveTokenToLocal = function(localToken, callback) {
         else if (!globalFuncs.isAlphaNumeric(localToken.symbol) || localToken.symbol == "") {throw globalFuncs.errorMsgs[19]}
         var storedTokens = globalFuncs.localStorage.getItem("localTokens", null) != null ? JSON.parse(globalFuncs.localStorage.getItem("localTokens")) : [];
 
-        // catch if already in storedTokens
+        // catch if TOKEN SYMBOL is already in storedTokens
         for (var i = 0; i < storedTokens.length; i++){
             if (storedTokens[i].symbol.toLowerCase().replace(/ /g, '') === localToken.symbol.toLowerCase().replace(/ /g, '')) {
               throw Error('ERROR: Unable to add a custom token with the same symbol as an existing custom token')
             }
         }
 
-        // catch if already in defaultTokens
+        // catch if CONTRACT ADDRESS is already in storedTokens
+        for (var i = 0; i < storedTokens.length; i++){
+            if (storedTokens[i].contractAddress.toLowerCase().replace(/ /g, '') === localToken.contractAdd.toLowerCase().replace(/ /g, '')) {
+              throw Error('ERROR: Unable to add a custom token with the same contract address as an existing custom token')
+            }
+        }
+
         var defaultTokensAndNetworkType = globalFuncs.getDefaultTokensAndNetworkType();
+
+        // catch if TOKEN SYMBOL is already in defaultTokens
         if (globalFuncs.doesTokenExistInDefaultTokens(localToken, defaultTokensAndNetworkType)) {
           throw Error('ERROR: Unable to add a custom token with the same symbol as an existing default token')
         }
 
-        storedTokens.push({
+        // catch if CONTRACT ADDRESS is already in defaultTokens
+        if (globalFuncs.doesTokenAddressExistInDefaultTokenAddresses(localToken, defaultTokensAndNetworkType)) {
+          throw Error('ERROR: Unable to add a custom token with the same contract address as an existing default token')
+        }
+
+      storedTokens.push({
             contractAddress: localToken.contractAdd,
             symbol: localToken.symbol,
             decimal: parseInt(localToken.decimals),


### PR DESCRIPTION
This PR introduces a check to prevent a user from adding a custom token with a contract address that's either (a) already in the default token list, or (b) already in their custom token list. 

I've tested this myself, but others should verify functionality before it's merged. 